### PR TITLE
Also detect .proto3 files for syntax

### DIFF
--- a/ftdetect/proto.vim
+++ b/ftdetect/proto.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.proto setfiletype proto
+autocmd BufNewFile,BufRead *.proto{3,} setfiletype proto


### PR DESCRIPTION
The plugin as it stands only detects `.proto` files for syntax highlighting. This PR edits the pattern so that it will additionally detect `.proto3` files for syntax highlighting.